### PR TITLE
Revert "Bump llama-index-vector-stores-couchbase from 0.6.0 to 0.7.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-llama-index-vector-stores-couchbase==0.7.1
+llama-index-vector-stores-couchbase==0.6.0
 llama-index-llms-openai==0.7.6
 llama-index-embeddings-openai==0.5.1
 llama-index-readers-file==0.6.0


### PR DESCRIPTION
Reverts couchbase-examples/rag-demo-llama-index#129